### PR TITLE
Use a stub app as the flatpak bootstrap.

### DIFF
--- a/{{ cookiecutter.formal_name }}/bootstrap
+++ b/{{ cookiecutter.formal_name }}/bootstrap
@@ -1,5 +1,0 @@
-#!/bin/bash
-export PYTHONPATH=/app/briefcase/app:/app/briefcase/app_packages
-# echo "PATH IS $PATH"
-# echo "PYTHONPATH IS $PYTHONPATH"
-/app/bin/python3 -s -m {{ cookiecutter.module_name }} "$@"

--- a/{{ cookiecutter.formal_name }}/manifest.yml
+++ b/{{ cookiecutter.formal_name }}/manifest.yml
@@ -4,6 +4,9 @@ runtime: {{ cookiecutter.flatpak_runtime }}
 runtime-version: '{{ cookiecutter.flatpak_runtime_version }}'
 sdk: {{ cookiecutter.flatpak_sdk }}
 command: {{ cookiecutter.app_name }}
+cleanup:
+  - /include
+  - /share/man
 finish-args:
   # X11 + XShm access
   - --share=ipc
@@ -21,9 +24,16 @@ finish-args:
   - --socket=session-bus
 modules:
   - name: cpython
+    config-opts:
+      - --enable-shared
     sources:
       - type: archive
         path: Python-{{ cookiecutter.python_version }}.tgz
+    cleanup:
+      - /bin/2to3*
+      - /bin/idle*
+      - /bin/py*
+      - /lib/python*/config-*
   - name: app_packages
     buildsystem: simple
     build-options:
@@ -43,17 +53,19 @@ modules:
       - type: dir
         path: src/app/
         dest: src/app/
-  - name: bootstrap
+  - name: resources
     buildsystem: simple
     build-commands:
-      - install -D bootstrap /app/bin/{{ cookiecutter.app_name }}
       - install -D {{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.desktop /app/share/applications/{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.desktop
       - cp -r icons /app/share/icons
     sources:
-      - type: file
-        path: bootstrap
       - type: file
         path: {{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.desktop
       - type: dir
         path: icons/
         dest: icons/
+  - name: bootstrap
+    no-autogen: true
+    sources:
+      - type: dir
+        path: src/bootstrap/

--- a/{{ cookiecutter.formal_name }}/src/bootstrap/Makefile
+++ b/{{ cookiecutter.formal_name }}/src/bootstrap/Makefile
@@ -1,0 +1,17 @@
+
+CFLAGS=$(shell /app/bin/python3-config --cflags)
+LDFLAGS=$(shell /app/bin/python3-config --ldflags)
+
+all: helloworld
+
+helloworld: main.c
+	gcc -o helloworld $^ $(CFLAGS) $(LDFLAGS) -lpython{{ '.'.join(cookiecutter.python_version.split('.')[:2]) }}
+
+clean:
+	rm -f helloworld
+
+install:
+	cp helloworld /app/bin/helloworld
+
+.PHONY: all clean install
+

--- a/{{ cookiecutter.formal_name }}/src/bootstrap/Makefile
+++ b/{{ cookiecutter.formal_name }}/src/bootstrap/Makefile
@@ -2,16 +2,16 @@
 CFLAGS=$(shell /app/bin/python3-config --cflags)
 LDFLAGS=$(shell /app/bin/python3-config --ldflags)
 
-all: helloworld
+all: {{ cookiecutter.app_name }}
 
-helloworld: main.c
-	gcc -o helloworld $^ $(CFLAGS) $(LDFLAGS) -lpython{{ '.'.join(cookiecutter.python_version.split('.')[:2]) }}
+{{ cookiecutter.app_name }}: main.c
+	gcc -o {{ cookiecutter.app_name }} $^ $(CFLAGS) $(LDFLAGS) -lpython{{ '.'.join(cookiecutter.python_version.split('.')[:2]) }}
 
 clean:
-	rm -f helloworld
+	rm -f {{ cookiecutter.app_name }}
 
 install:
-	cp helloworld /app/bin/helloworld
+	cp {{ cookiecutter.app_name }} /app/bin/{{ cookiecutter.app_name }}
 
 .PHONY: all clean install
 

--- a/{{ cookiecutter.formal_name }}/src/bootstrap/main.c
+++ b/{{ cookiecutter.formal_name }}/src/bootstrap/main.c
@@ -1,0 +1,213 @@
+//
+//  main.c
+//  A main module for starting Python projects on Linux.
+//
+#include <wchar.h>
+#include <stdio.h>
+#include <Python.h>
+
+int main(int argc, char *argv[]) {
+    int ret = 0;
+    PyStatus status;
+    PyConfig config;
+    char *python_home;
+    char *app_module_name;
+    char *path;
+    wchar_t *wapp_module_name;
+    wchar_t *wtmp_str;
+    PyObject *app_module;
+    PyObject *module;
+    PyObject *module_attr;
+    PyObject *method_args;
+    PyObject *result;
+    PyObject *exc_type;
+    PyObject *exc_value;
+    PyObject *exc_traceback;
+    PyObject *systemExit_code;
+
+    // Generate an isolated Python configuration.
+    PyConfig_InitIsolatedConfig(&config);
+
+    // Configure the Python interpreter:
+    // Run at optimization level 1
+    // (remove assertions, set __debug__ to False)
+    config.optimization_level = 1;
+    // Don't buffer stdio. We want output to appears in the log immediately
+    config.buffered_stdio = 0;
+    // Don't write bytecode; we can't modify the app bundle
+    // after it has been signed.
+    config.write_bytecode = 0;
+    // Isolated apps need to set the full PYTHONPATH manually.
+    config.module_search_paths_set = 1;
+
+    // Set the home for the Python interpreter
+    python_home = "/app";
+    printf("PYTHONHOME: %s\n", python_home);
+    wtmp_str = Py_DecodeLocale(python_home, NULL);
+    status = PyConfig_SetString(&config, &config.home, wtmp_str);
+    if (PyStatus_Exception(status)) {
+        // crash_dialog("Unable to set PYTHONHOME: %s", status.err_msg]);
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+    }
+    PyMem_RawFree(wtmp_str);
+
+    // Determine the app module name
+    wapp_module_name = Py_DecodeLocale("{{ cookiecutter.module_name }}", NULL);
+    status = PyConfig_SetString(&config, &config.run_module, wapp_module_name);
+    if (PyStatus_Exception(status)) {
+        // crash_dialog("Unable to set app module name: %s", status.err_msg);
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+    }
+
+    // Read the site config
+    status = PyConfig_Read(&config);
+    if (PyStatus_Exception(status)) {
+        // crash_dialog("Unable to read site config: %s", status.err_msg]);
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+    }
+
+    // Set the full module path. This includes the stdlib, site-packages, and app code.
+    printf("PYTHONPATH:\n");
+    // // The .zip form of the stdlib
+    path = "/app/lib/python{{ ''.join(cookiecutter.python_version.split('.')[:2]) }}.zip";
+    printf("- %s\n", path);
+    wtmp_str = Py_DecodeLocale(path, NULL);
+    status = PyWideStringList_Append(&config.module_search_paths, wtmp_str);
+    if (PyStatus_Exception(status)) {
+        // crash_dialog("Unable to set .zip form of stdlib path: %s", status.err_msg);
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+    }
+    PyMem_RawFree(wtmp_str);
+
+    // The unpacked form of the stdlib
+    path = "/app/lib/python{{ '.'.join(cookiecutter.python_version.split('.')[:2]) }}";
+    printf("- %s\n", path);
+    wtmp_str = Py_DecodeLocale(path, NULL);
+    status = PyWideStringList_Append(&config.module_search_paths, wtmp_str);
+    if (PyStatus_Exception(status)) {
+        // crash_dialog("Unable to set unpacked form of stdlib path: %s", status.err_msg);
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+    }
+    PyMem_RawFree(wtmp_str);
+
+    // Add the stdlib binary modules path
+    path = "/app/lib/python{{ '.'.join(cookiecutter.python_version.split('.')[:2]) }}/lib-dynload";
+    printf("- %s\n", path);
+    wtmp_str = Py_DecodeLocale(path, NULL);
+    status = PyWideStringList_Append(&config.module_search_paths, wtmp_str);
+    if (PyStatus_Exception(status)) {
+        // crash_dialog("Unable to set stdlib binary module path: %s", status.err_msg);
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+    }
+    PyMem_RawFree(wtmp_str);
+
+    // Add the app path
+    path = "/app/briefcase/app";
+    printf("- %s\n", path);
+    wtmp_str = Py_DecodeLocale(path, NULL);
+    status = PyWideStringList_Append(&config.module_search_paths, wtmp_str);
+    if (PyStatus_Exception(status)) {
+        // crash_dialog("Unable to set app path: %s", status.err_msg);
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+    }
+    PyMem_RawFree(wtmp_str);
+
+    printf("Configure argc/argv...\n");
+    status = PyConfig_SetBytesArgv(&config, argc, argv);
+    if (PyStatus_Exception(status)) {
+        // crash_dialog("Unable to configured argc/argv: %s", status.err_msg);
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+    }
+
+    printf("Initializing Python runtime...\n");
+    status = Py_InitializeFromConfig(&config);
+    if (PyStatus_Exception(status)) {
+        // crash_dialog("Unable to initialize Python interpreter: %s", status.err_msg);
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+    }
+
+    // Start the app module.
+    //
+    // From here to Py_ObjectCall(runmodule...) is effectively
+    // a copy of Py_RunMain() (and, more  specifically, the
+    // pymain_run_module() method); we need to re-implement it
+    // because we need to be able to inspect the error state of
+    // the interpreter, not just the return code of the module.
+    wprintf(L"Running app module: %s", app_module_name);
+    module = PyImport_ImportModule("runpy");
+    if (module == NULL) {
+        // crash_dialog(@"Could not import runpy module");
+        exit(-2);
+    }
+
+    module_attr = PyObject_GetAttrString(module, "_run_module_as_main");
+    if (module_attr == NULL) {
+        // crash_dialog(@"Could not access runpy._run_module_as_main");
+        exit(-3);
+    }
+
+    app_module = PyUnicode_FromWideChar(wapp_module_name, wcslen(wapp_module_name));
+    if (app_module == NULL) {
+        // crash_dialog(@"Could not convert module name to unicode");
+        exit(-3);
+    }
+
+    method_args = Py_BuildValue("(Oi)", app_module, 0);
+    if (method_args == NULL) {
+        // crash_dialog(@"Could not create arguments for runpy._run_module_as_main");
+        exit(-4);
+    }
+
+    result = PyObject_Call(module_attr, method_args, NULL);
+
+    if (result == NULL) {
+        // Retrieve the current error state of the interpreter.
+        PyErr_Fetch(&exc_type, &exc_value, &exc_traceback);
+        PyErr_NormalizeException(&exc_type, &exc_value, &exc_traceback);
+
+        if (exc_traceback == NULL) {
+            // crash_dialog(@"Could not retrieve traceback");
+            exit(-5);
+        }
+
+        if (PyErr_GivenExceptionMatches(exc_value, PyExc_SystemExit)) {
+            systemExit_code = PyObject_GetAttrString(exc_value, "code");
+            if (systemExit_code == NULL) {
+                printf("Could not determine exit code\n");
+                ret = -10;
+            }
+            else {
+                ret = (int) PyLong_AsLong(systemExit_code);
+            }
+        } else {
+            ret = -6;
+        }
+
+        if (ret != 0) {
+            printf("Application quit abnormally (Exit code %d)!\n", ret);
+
+            // Restore the error state of the interpreter.
+            PyErr_Restore(exc_type, exc_value, exc_traceback);
+
+            // Print exception to stderr.
+            // In case of SystemExit, this will call exit()
+            PyErr_Print();
+
+            exit(ret);
+        }
+    }
+
+    Py_Finalize();
+    PyMem_RawFree(wapp_module_name);
+
+    return ret;
+}


### PR DESCRIPTION
Since building a Flatpak involves building everything from source anyway, this provides a convenient entry point to use a genuine stub app, rather than a shell script wrapping the Python interpreter. 

This matches what is done with macOS and Windows apps. It provides complete control over the interpreter, and isolation from the environment in which the app runs. 

Fixes beeware/briefcase#628
Refs beeware/briefcase#662
Addresses the flatpak edge case mentioned in beeware/briefcase#803.

This PR also enables dynamic linking, and strips unused parts of the bundle. This has the effect of reducing the size of a packaged HelloWorld Toga app from 42MB to 28MB.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
