### PR TITLE
Add --filesystem=host to app_packages module

### DIFF
--- a/{{ cookiecutter.formal_name }}/manifest.yml
+++ b/{{ cookiecutter.formal_name }}/manifest.yml
@@ -38,7 +38,8 @@ modules:
     buildsystem: simple
     build-options:
       build-args:
-        - --share=network
+        - --filesystem=host  # For local requirements.
+        - --share=network  # For downloaded requirements.
     build-commands:
       - pip3 install -r requirements.txt
     sources:


### PR DESCRIPTION
As it says in the "Build environment" section at the bottom of [this page](https://docs.flatpak.org/en/latest/flatpak-builder-command-reference.html), Flatpak module builds are done in a sandbox, so they need to be explicitly given access to the host filesystem. This is necessary in order to install requirements from local directories or files.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
