### PR TITLE
Disable the pip cache directory when building app

### DIFF
--- a/{{ cookiecutter.formal_name }}/manifest.yml
+++ b/{{ cookiecutter.formal_name }}/manifest.yml
@@ -41,7 +41,7 @@ modules:
         - --filesystem=host  # For local requirements.
         - --share=network  # For downloaded requirements.
     build-commands:
-      - pip3 install -r requirements.txt
+      - pip3 install --no-cache-dir -r requirements.txt
     sources:
       - type: file
         path: requirements.txt


### PR DESCRIPTION
 - To allow users to install local packages, the host filesystem is exposed to the Flatpak build environment. Disabling the pip cache directory prevents pip installing wheels built against the host system which may be incompatible with other Flatpak layers.
 - Fixes beeware/briefcase#858

There may be better fixes (like creating a blocklist of directories not to expose to Flatpak (assuming that's even possible)) but disabling the pip cache directory doesn't actually require wheels to be rebuilt every time. If the requirements file is the same as last time, then the Flatpak build cache is used instead of rerunning `pip install`.

Log excerpt when rebuilding a Flatpak app:
```
[flatcache] Building Flatpak...
Emptying app dir 'build'
Downloading sources
Starting build of com.example.flatcache
Cache hit for cpython, skipping build
Cache hit for app_packages, skipping build   <<<< relevant cache hit
Cache miss, checking out last cache hit
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
