### PR TITLE
Force installation of requirements into an app_packages folder.

### DIFF
--- a/{{ cookiecutter.formal_name }}/manifest.yml
+++ b/{{ cookiecutter.formal_name }}/manifest.yml
@@ -32,7 +32,6 @@ modules:
     cleanup:
       - /bin/2to3*
       - /bin/idle*
-      - /bin/py*
       - /lib/python*/config-*
   - name: app_packages
     buildsystem: simple
@@ -41,7 +40,8 @@ modules:
         - --filesystem=host  # For local requirements.
         - --share=network  # For downloaded requirements.
     build-commands:
-      - pip3 install --no-cache-dir -r requirements.txt
+      - mkdir -p /app/briefcase/app_packages
+      - /app/bin/python3 -m pip install --no-cache-dir -r requirements.txt --target /app/briefcase/app_packages
     sources:
       - type: file
         path: requirements.txt

--- a/{{ cookiecutter.formal_name }}/src/bootstrap/main.c
+++ b/{{ cookiecutter.formal_name }}/src/bootstrap/main.c
@@ -122,6 +122,18 @@ int main(int argc, char *argv[]) {
     }
     PyMem_RawFree(wtmp_str);
 
+    // Add the app_packages path
+    path = "/app/briefcase/app_packages";
+    printf("- %s\n", path);
+    wtmp_str = Py_DecodeLocale(path, NULL);
+    status = PyWideStringList_Append(&config.module_search_paths, wtmp_str);
+    if (PyStatus_Exception(status)) {
+        // crash_dialog("Unable to set app path: %s", status.err_msg);
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+    }
+    PyMem_RawFree(wtmp_str);
+
     // Add the app path
     path = "/app/briefcase/app";
     printf("- %s\n", path);


### PR DESCRIPTION
Reported via discord:

If a user *doesn't* use a virtual environment, and they build a flatpak, any packages that they have installed in their system are taken into consideration when installing packages into the flatpak.

For example - if the user has toga installed in their system Python (even if it is their user `.local` install), the flatpak *won't* install toga as a dependency, as pip determines that the package is already available.

This can be fixed by using `--target` when doing the pip install. 

This PR introduces an explicit app_packages folder, and `pip install`s into that folder as a target. It also ensures that pip is invoked with the version of Python that is in the Flatpak sandbox, rather than relying on the `pip3` shortcut, which is ambiguous.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
