### PR TITLE
Disable Wayland access

### DIFF
--- a/{{ cookiecutter.formal_name }}/manifest.yml
+++ b/{{ cookiecutter.formal_name }}/manifest.yml
@@ -11,8 +11,8 @@ finish-args:
   # X11 + XShm access
   - --share=ipc
   - --socket=x11
-  # Wayland access
-  - --socket=wayland
+  # Disable Wayland access
+  - --nosocket=wayland
   # Needs to talk to the network:
   - --share=network
   # Needs to save files locally
@@ -33,6 +33,22 @@ modules:
       - /bin/2to3*
       - /bin/idle*
       - /lib/python*/config-*
+  - name: bootstrap
+    no-autogen: true
+    sources:
+      - type: dir
+        path: src/bootstrap/
+  - name: resources
+    buildsystem: simple
+    build-commands:
+      - install -D {{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.desktop /app/share/applications/{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.desktop
+      - cp -r icons /app/share/icons
+    sources:
+      - type: file
+        path: {{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.desktop
+      - type: dir
+        path: icons/
+        dest: icons/
   - name: app_packages
     buildsystem: simple
     build-options:
@@ -54,19 +70,3 @@ modules:
       - type: dir
         path: src/app/
         dest: src/app/
-  - name: resources
-    buildsystem: simple
-    build-commands:
-      - install -D {{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.desktop /app/share/applications/{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.desktop
-      - cp -r icons /app/share/icons
-    sources:
-      - type: file
-        path: {{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.desktop
-      - type: dir
-        path: icons/
-        dest: icons/
-  - name: bootstrap
-    no-autogen: true
-    sources:
-      - type: dir
-        path: src/bootstrap/


### PR DESCRIPTION
In my testing, PySide6 doesn't display window chrome if the wayland socket is open. Ultimately, we're going to want to make these permissions user-configurable; but for now, a set of defaults that work for the demo apps seems preferable. 

This also re-orders the build so that bootstrap and resources (which are less likely to change) occur earlier, so they (in theory) should result in faster builds due to not spoiling the build cache.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
