### PR TITLE
Switch to using bundle_identifier

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,6 +5,7 @@
     "module_name": "{{ cookiecutter.app_name|replace('-', '_') }}",
     "version": "1.0",
     "bundle": "com.example",
+    "bundle_identifier": "{{ cookiecutter.bundle }}.{{ cookiecutter.app_name|replace('_', '-') }}",
     "url": "https://example.com",
     "description": "Short description of app",
     "flatpak_runtime": "org.freedesktop.Platform",

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -11,10 +11,10 @@ support_path = "support"
 }.get(cookiecutter.python_version|py_tag, "") }}
 
 
-icon.16 = "icons/hicolor/16x16/apps/{{ cookiecutter.bundle}}.{{ cookiecutter.app_name }}.png"
-icon.32 = "icons/hicolor/32x32/apps/{{ cookiecutter.bundle}}.{{ cookiecutter.app_name }}.png"
-icon.64 = "icons/hicolor/64x64/apps/{{ cookiecutter.bundle}}.{{ cookiecutter.app_name }}.png"
-icon.128 = "icons/hicolor/128x128/apps/{{ cookiecutter.bundle}}.{{ cookiecutter.app_name }}.png"
-icon.256 = "icons/hicolor/256x256/apps/{{ cookiecutter.bundle}}.{{ cookiecutter.app_name }}.png"
-icon.512 = "icons/hicolor/512x512/apps/{{ cookiecutter.bundle}}.{{ cookiecutter.app_name }}.png"
-# icon.scalable = "icons/hicolor/scalable/apps/{{ cookiecutter.bundle}}.{{ cookiecutter.app_name }}.png"
+icon.16 = "icons/hicolor/16x16/apps/{{ cookiecutter.bundle_identifier }}.png"
+icon.32 = "icons/hicolor/32x32/apps/{{ cookiecutter.bundle_identifier }}.png"
+icon.64 = "icons/hicolor/64x64/apps/{{ cookiecutter.bundle_identifier }}.png"
+icon.128 = "icons/hicolor/128x128/apps/{{ cookiecutter.bundle_identifier }}.png"
+icon.256 = "icons/hicolor/256x256/apps/{{ cookiecutter.bundle_identifier }}.png"
+icon.512 = "icons/hicolor/512x512/apps/{{ cookiecutter.bundle_identifier }}.png"
+# icon.scalable = "icons/hicolor/scalable/apps/{{ cookiecutter.bundle_identifier }}.png"

--- a/{{ cookiecutter.format }}/manifest.yml
+++ b/{{ cookiecutter.format }}/manifest.yml
@@ -1,4 +1,4 @@
-app-id: {{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}
+app-id: {{ cookiecutter.bundle_identifier }}
 default-branch: {{ cookiecutter.version }}
 runtime: {{ cookiecutter.flatpak_runtime }}
 runtime-version: '{{ cookiecutter.flatpak_runtime_version }}'
@@ -48,11 +48,11 @@ modules:
   - name: resources
     buildsystem: simple
     build-commands:
-      - install -D {{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.desktop /app/share/applications/{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.desktop
+      - install -D {{ cookiecutter.bundle_identifier }}.desktop /app/share/applications/{{ cookiecutter.bundle_identifier }}.desktop
       - cp -r icons /app/share/icons
     sources:
       - type: file
-        path: {{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}.desktop
+        path: {{ cookiecutter.bundle_identifier }}.desktop
       - type: dir
         path: icons/
         dest: icons/

--- a/{{ cookiecutter.format }}/{{ cookiecutter.bundle_identifier }}.desktop
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.bundle_identifier }}.desktop
@@ -2,5 +2,5 @@
 Type=Application
 Name={{ cookiecutter.formal_name }}
 Exec={{ cookiecutter.app_name }} %F
-Icon={{ cookiecutter.bundle}}.{{ cookiecutter.app_name }}
+Icon={{ cookiecutter.bundle_identifier }}
 Comment={{ cookiecutter.description }}


### PR DESCRIPTION
Updates all of the locations in the cookiecutter template to make use of `bundle_identifier` instead of manually forming it.

Refs https://github.com/beeware/briefcase/pull/1234

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
