### PR TITLE
Update standalone Python from 20230116 to 20230507

### DIFF
--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -4,10 +4,10 @@ app_path = "src/app"
 app_requirements_path = "requirements.txt"
 support_path = "support"
 {{ {
-    "3.8": 'support_revision = "3.8.16+20230116"',
-    "3.9": 'support_revision = "3.9.16+20230116"',
-    "3.10": 'support_revision = "3.10.9+20230116"',
-    "3.11": 'support_revision = "3.11.1+20230116"',
+    "3.8": 'support_revision = "3.8.16+20230507"',
+    "3.9": 'support_revision = "3.9.16+20230507"',
+    "3.10": 'support_revision = "3.10.11+20230507"',
+    "3.11": 'support_revision = "3.11.3+20230507"',
 }.get(cookiecutter.python_version|py_tag, "") }}
 
 


### PR DESCRIPTION
## Changes
- CPython 3.11.1 -> 3.11.3
- CPython 3.10.9 -> 3.10.11
- pip 22.3.1 -> 23.1.2
- setuptools 65.6.3 -> 67.7.2
- Add ppc64le-unknown-linux-gnu distributions for CPython 3.9, 3.10, and 3.11
- SQLite 3.40.1 -> 3.41.2
- binutils 2.39 -> 2.40
- LLVM 15.0.7 -> 16.0.3

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
