### PR TITLE
Add updated support packages and CI for Python 3.12 support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         # Pyside2 and Pyside6, and PPB configs aren't known to work on Linux Flatpak at this time.
         framework: [ "toga", "pygame" ]

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -4,10 +4,11 @@ app_path = "src/app"
 app_requirements_path = "requirements.txt"
 support_path = "support"
 {{ {
-    "3.8": 'support_revision = "3.8.17+20230826"',
-    "3.9": 'support_revision = "3.9.18+20230826"',
-    "3.10": 'support_revision = "3.10.13+20230826"',
-    "3.11": 'support_revision = "3.11.5+20230826"',
+    "3.8": 'support_revision = "3.8.18+20231002"',
+    "3.9": 'support_revision = "3.9.18+20231002"',
+    "3.10": 'support_revision = "3.10.13+20231002"',
+    "3.11": 'support_revision = "3.11.6+20231002"',
+    "3.12": 'support_revision = "3.12.0+20231002"',
 }.get(cookiecutter.python_version|py_tag, "") }}
 
 

--- a/{{ cookiecutter.format }}/manifest.yml
+++ b/{{ cookiecutter.format }}/manifest.yml
@@ -32,6 +32,10 @@ modules:
       - cp -r support/python/include/* /app/include
       - mkdir -p /app/lib
       - cp -r support/python/lib/* /app/lib
+      # Remove clang-specific flags from configurations
+      - sed -e "s/-fdebug-default-version=4//g" support/python/bin/python3-config > /app/bin/python3-config
+      - sed -e "s/-fdebug-default-version=4//g" support/python/bin/python3.{{ cookiecutter.python_version.split('.')[1] }}-config > /app/bin/python3.{{ cookiecutter.python_version.split('.')[1] }}-config
+      - sed -e "s/-fdebug-default-version=4//g" support/python/lib/python3.{{ cookiecutter.python_version.split('.')[1] }}/_sysconfigdata__linux_x86_64-linux-gnu.py > /app/lib/python3.{{ cookiecutter.python_version.split('.')[1] }}/_sysconfigdata__linux_x86_64-linux-gnu.py
     sources:
       - type: dir
         path: support/python


### PR DESCRIPTION
Add Python 3.12 support, based on the 20231002 release of Python-build-standalone.

The new release includes the use of a clang-specific feature (`-fdebug-default-version=4`); this flag isn't available on gcc, and in order to use clang in the Flatpak container, we'd need to *compile* clang - so this takes the pragmatic approach of patching out that flag from python-config and sysconfig.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
