### PR TITLE
Install the latest version for requirements in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
       - main
   workflow_call:
 
+# Cancel active CI runs for a PR before starting another run
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash  # https://github.com/beeware/briefcase/pull/912

--- a/tests/apps/verify-pygame/pyproject.toml
+++ b/tests/apps/verify-pygame/pyproject.toml
@@ -4,16 +4,16 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org/"
 license = "BSD license"
-author = 'Brutus'
+author = "Brutus"
 author_email = "contact@beeware.org"
 
 [tool.briefcase.app.verify-pygame]
 formal_name = "Hello Pygame"
 description = "A Pygame test app"
 icon = "src/verify_pygame/resources/verify-pygame"
-sources = ['src/verify_pygame']
+sources = ["src/verify_pygame"]
 requires = [
-    'pygame~=2.2.0',
+    "pygame>=2.5",
 ]
 
 [tool.briefcase.app.verify-pygame.linux]
@@ -21,7 +21,7 @@ requires = [
 ]
 
 [tool.briefcase.app.verify-pygame.linux.flatpak]
-flatpak_runtime = 'org.gnome.Platform'
-flatpak_runtime_version = '42'
-flatpak_sdk = 'org.gnome.Sdk'
-template = '../../../'
+flatpak_runtime = "org.gnome.Platform"
+flatpak_runtime_version = "44"
+flatpak_sdk = "org.gnome.Sdk"
+template = "../../../"

--- a/tests/apps/verify-toga/pyproject.toml
+++ b/tests/apps/verify-toga/pyproject.toml
@@ -4,25 +4,25 @@ bundle = "org.beeware"
 version = "0.0.1"
 url = "https://beeware.org/"
 license = "BSD license"
-author = 'Brutus'
+author = "Brutus"
 author_email = "contact@beeware.org"
 
 [tool.briefcase.app.verify-toga]
 formal_name = "Hello Toga"
 description = "A Toga test app"
 icon = "src/verify_toga/resources/verify-toga"
-sources = ['src/verify_toga']
+sources = ["src/verify_toga"]
 requires = [
 ]
 
 
 [tool.briefcase.app.verify-toga.linux]
 requires = [
-    'toga-gtk>=0.3.0.dev38',
+    "toga-gtk>=0.3.1",
 ]
 
 [tool.briefcase.app.verify-toga.linux.flatpak]
-flatpak_runtime = 'org.gnome.Platform'
-flatpak_runtime_version = '44'
-flatpak_sdk = 'org.gnome.Sdk'
-template = '../../../'
+flatpak_runtime = "org.gnome.Platform"
+flatpak_runtime_version = "44"
+flatpak_sdk = "org.gnome.Sdk"
+template = "../../../"


### PR DESCRIPTION
Always install the latest version of requirements for testing app builds, notably for `pygame`.

Dependent on https://github.com/beeware/.github/pull/59; here is [passing CI](https://github.com/beeware/briefcase-linux-flatpak-template/actions/runs/6630065458/job/18010725638) using it, though. Notice that the most recent CI doesn't really test PyGame at all since it doesn't actually build anything.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
