### PR TITLE
Remove clang config from Python irrespective of arch

### DIFF
--- a/{{ cookiecutter.format }}/manifest.yml
+++ b/{{ cookiecutter.format }}/manifest.yml
@@ -33,6 +33,7 @@ modules:
       - mkdir -p /app/lib
       - cp -r support/python/lib/* /app/lib
       # Remove clang-specific flags from configurations
+      - sed -i "s/-fdebug-default-version=4//g" /app/bin/python3-config
       - sed -i "s/-fdebug-default-version=4//g" /app/bin/python3.{{ cookiecutter.python_version.split('.')[1] }}-config
       - find /app/lib/python3.{{ cookiecutter.python_version.split('.')[1] }}/ -maxdepth 1 -name '_sysconfigdata_*.py' -exec sed -i "s/-fdebug-default-version=4//g" {} \;
     sources:

--- a/{{ cookiecutter.format }}/manifest.yml
+++ b/{{ cookiecutter.format }}/manifest.yml
@@ -33,7 +33,6 @@ modules:
       - mkdir -p /app/lib
       - cp -r support/python/lib/* /app/lib
       # Remove clang-specific flags from configurations
-      - sed -i "s/-fdebug-default-version=4//g" /app/bin/python3-config
       - sed -i "s/-fdebug-default-version=4//g" /app/bin/python3.{{ cookiecutter.python_version.split('.')[1] }}-config
       - find /app/lib/python3.{{ cookiecutter.python_version.split('.')[1] }}/ -maxdepth 1 -name '_sysconfigdata_*.py' -exec sed -i "s/-fdebug-default-version=4//g" {} \;
     sources:

--- a/{{ cookiecutter.format }}/manifest.yml
+++ b/{{ cookiecutter.format }}/manifest.yml
@@ -33,9 +33,9 @@ modules:
       - mkdir -p /app/lib
       - cp -r support/python/lib/* /app/lib
       # Remove clang-specific flags from configurations
-      - sed -e "s/-fdebug-default-version=4//g" support/python/bin/python3-config > /app/bin/python3-config
-      - sed -e "s/-fdebug-default-version=4//g" support/python/bin/python3.{{ cookiecutter.python_version.split('.')[1] }}-config > /app/bin/python3.{{ cookiecutter.python_version.split('.')[1] }}-config
-      - sed -e "s/-fdebug-default-version=4//g" support/python/lib/python3.{{ cookiecutter.python_version.split('.')[1] }}/_sysconfigdata__linux_x86_64-linux-gnu.py > /app/lib/python3.{{ cookiecutter.python_version.split('.')[1] }}/_sysconfigdata__linux_x86_64-linux-gnu.py
+      - sed -i "s/-fdebug-default-version=4//g" /app/bin/python3-config
+      - sed -i "s/-fdebug-default-version=4//g" /app/bin/python3.{{ cookiecutter.python_version.split('.')[1] }}-config
+      - find /app/lib/python3.{{ cookiecutter.python_version.split('.')[1] }}/ -maxdepth 1 -name '_sysconfigdata_*.py' -exec sed -i "s/-fdebug-default-version=4//g" {} \;
     sources:
       - type: dir
         path: support/python


### PR DESCRIPTION
## Changes
- Run `sed` over "all" `_sysconfigdata_*.py` files in `lib`
  - In practice, there should just be one of these...but this avoids the need to understand the Python architecture that's a part of the file name
- Closes beeware/briefcase#1511

## Notes
- I noticed that the `-fdebug-default-version` flag is only [used](https://github.com/search?q=repo%3Aindygreg%2Fpython-build-standalone%20%20fdebug-default-version&type=code) in the x86-64 builds...so, i guess this could be limited to only running for x86-64 Python...but same same

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
