### PR TITLE
Do not strip libraries from PyPI packages

### DIFF
--- a/{{ cookiecutter.format }}/manifest.yml
+++ b/{{ cookiecutter.format }}/manifest.yml
@@ -70,6 +70,8 @@ modules:
   - name: app_packages
     buildsystem: simple
     build-options:
+      strip: false
+      no-debuginfo: true
       build-args:
         - --filesystem=host  # For local requirements.
         - --share=network  # For downloaded requirements.
@@ -86,6 +88,9 @@ modules:
         path: requirements.txt
   - name: app
     buildsystem: simple
+    build-options:
+      strip: false
+      no-debuginfo: true
     build-commands:
       - mkdir -p /app/briefcase
       - cp -r src/app/ /app/briefcase/app


### PR DESCRIPTION
## Changes
- We've had issues with stripping libraries from PyPI before; this disables for Flatpak builds.
- This is noticeably a problem for PySide2...although, PySide6 seemingly survives the stripping....either way, it seems a better policy to leave these libraries as-is

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
