### PR TITLE
Allow access to GPU and sound

### DIFF
--- a/{{ cookiecutter.format }}/manifest.yml
+++ b/{{ cookiecutter.format }}/manifest.yml
@@ -13,9 +13,13 @@ finish-args:
   - --socket=x11
   # Disable Wayland access
   - --nosocket=wayland
-  # Needs to talk to the network:
+  # Network access
   - --share=network
-  # Needs to save files locally
+  # GPU access
+  - --device=dri
+  # Sound access
+  - --socket=pulseaudio
+  # Host filesystem access
   - --filesystem=xdg-cache
   - --filesystem=xdg-config
   - --filesystem=xdg-data


### PR DESCRIPTION
## Changes
- Update Flatpak manifest to allow access to GPU and sound
- Several of the non-Toga GUI toolkits need at least GPU permissions to run

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
