### PR TITLE
Bump Python from 20231002 to 20240107

### DIFF
--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -4,11 +4,11 @@ app_path = "src/app"
 app_requirements_path = "requirements.txt"
 support_path = "support"
 {{ {
-    "3.8": 'support_revision = "3.8.18+20231002"',
-    "3.9": 'support_revision = "3.9.18+20231002"',
-    "3.10": 'support_revision = "3.10.13+20231002"',
-    "3.11": 'support_revision = "3.11.6+20231002"',
-    "3.12": 'support_revision = "3.12.0+20231002"',
+    "3.8": 'support_revision = "3.8.18+20240107"',
+    "3.9": 'support_revision = "3.9.18+20240107"',
+    "3.10": 'support_revision = "3.10.13+20240107"',
+    "3.11": 'support_revision = "3.11.7+20240107"',
+    "3.12": 'support_revision = "3.12.1+20240107"',
 }.get(cookiecutter.python_version|py_tag, "") }}
 
 

--- a/{{ cookiecutter.format }}/manifest.yml
+++ b/{{ cookiecutter.format }}/manifest.yml
@@ -36,10 +36,6 @@ modules:
       - cp -r support/python/include/* /app/include
       - mkdir -p /app/lib
       - cp -r support/python/lib/* /app/lib
-      # Remove clang-specific flags from configurations
-      - sed -i "s/-fdebug-default-version=4//g" /app/bin/python3-config
-      - sed -i "s/-fdebug-default-version=4//g" /app/bin/python3.{{ cookiecutter.python_version.split('.')[1] }}-config
-      - find /app/lib/python3.{{ cookiecutter.python_version.split('.')[1] }}/ -maxdepth 1 -name '_sysconfigdata_*.py' -exec sed -i "s/-fdebug-default-version=4//g" {} \;
     sources:
       - type: dir
         path: support/python


### PR DESCRIPTION
## Changes
- Release [20240107](https://github.com/indygreg/python-build-standalone/releases) [restores](https://github.com/indygreg/python-build-standalone/issues/194) gcc compatibility and no longer [links](https://github.com/indygreg/python-build-standalone/issues/197) `libcrypt.so` for Python 3.8, 3.9, and 3.10.

## Notes
- https://github.com/beeware/.github/pull/79 should be merged first and this PR's CI should be re-run before merging.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct