### PR TITLE
Update Python's installation prefix

### DIFF
--- a/{{ cookiecutter.format }}/manifest.yml
+++ b/{{ cookiecutter.format }}/manifest.yml
@@ -25,6 +25,9 @@ modules:
       - cp -r support/python/include/* /app/include
       - mkdir -p /app/lib
       - cp -r support/python/lib/* /app/lib
+      # Update installation prefix for pip package builds
+      - sed --follow-symlinks -i 's/prefix="\/install"/prefix="\/app"/g' /app/bin/python3-config
+      - sed --follow-symlinks -i 's/prefix=\/install/prefix=\/app/g' /app/lib/pkgconfig/python3.pc /app/lib/pkgconfig/python3-embed.pc
     sources:
       - type: dir
         path: support/python

--- a/{{ cookiecutter.format }}/manifest.yml
+++ b/{{ cookiecutter.format }}/manifest.yml
@@ -20,11 +20,11 @@ modules:
     buildsystem: simple
     build-commands:
       - mkdir -p /app/bin
-      - cp -r support/python/bin/* /app/bin
+      - cp --archive support/python/bin/* /app/bin
       - mkdir -p /app/include
-      - cp -r support/python/include/* /app/include
+      - cp --archive support/python/include/* /app/include
       - mkdir -p /app/lib
-      - cp -r support/python/lib/* /app/lib
+      - cp --archive support/python/lib/* /app/lib
       # Update installation prefix for pip package builds
       - sed --follow-symlinks -i 's/prefix="\/install"/prefix="\/app"/g' /app/bin/python3-config
       - sed --follow-symlinks -i 's/prefix=\/install/prefix=\/app/g' /app/lib/pkgconfig/python3.pc /app/lib/pkgconfig/python3-embed.pc
@@ -45,7 +45,7 @@ modules:
     buildsystem: simple
     build-commands:
       - install -D {{ cookiecutter.bundle_identifier }}.desktop /app/share/applications/{{ cookiecutter.bundle_identifier }}.desktop
-      - cp -r icons /app/share/icons
+      - cp --archive icons /app/share/icons
     sources:
       - type: file
         path: {{ cookiecutter.bundle_identifier }}.desktop
@@ -86,7 +86,7 @@ modules:
       no-debuginfo: true
     build-commands:
       - mkdir -p /app/briefcase
-      - cp -r src/app/ /app/briefcase/app
+      - cp --archive src/app/ /app/briefcase/app
     sources:
       - type: dir
         path: src/app/


### PR DESCRIPTION
## Changes
- Resolves recent [issues](https://github.com/beeware/briefcase/pull/1689) with building Flatpaks because of changes to PyGObject's build process
  - PyGObject seems to have updated from `setup.py` to meson-python
  - When meson-python builds PyGObject, it adds the `include` directory that was used to build Python but Standalone Python is reporting that's `/install`....in actuality, we've installed Python in to `/app`
- So, this updates the buildtime installation prefix of `/install` to `/app`
- Additionally, the `cp -r` commands are replaced with `cp --archive` to avoid changing any of the metadata or filesystem layout of Python or the app when they are copied in to the Flatpak

## Notes
- This issue of buildtime absolute paths is called out in Standalone Python's docs: https://gregoryszorc.com/docs/python-build-standalone/main/quirks.html#references-to-build-time-paths
- I only updated the prefix in the `bin/python3-config` and `lib/pkgconfig/python3.pc` files
- There's also plenty to update in the `_sysconfigdata_` file....but it's less straightforward; just a naive `sed` for `/install` will catch other values.
  - I suppose we could target most of them, though, after empirically reviewing the files:
    - ` '/install/` -> ` '/app/`
    - `=/install` -> `=/app`
    - ` /install` -> ` /app`
- A different approach altogether, perhaps, would be to actually install Python to `/install`...

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct