### PR TITLE
Ensure that sys.executable returns the correct value

### DIFF
--- a/{{ cookiecutter.format }}/src/bootstrap/main.c
+++ b/{{ cookiecutter.format }}/src/bootstrap/main.c
@@ -61,6 +61,14 @@ int main(int argc, char *argv[]) {
     }
     PyMem_RawFree(wtmp_str);
 
+    // Set the executable name to match argv[0]
+    status = PyConfig_SetBytesString(&config, &config.executable, argv[0]);
+    if (PyStatus_Exception(status)) {
+        // crash_dialog("Unable to set executable name: %s", status.err_msg);
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+    }
+
     // Determine the app module name. Look for the BRIEFCASE_MAIN_MODULE
     // environment variable first; if that exists, we're probably in test
     // mode. If it doesn't exist, fall back to the MainModule key in the


### PR DESCRIPTION
The current stub binary used in a packaged system app returns sys.executable as python3. This is neither correct, nor helpful. 

We can use argv[0] (unlike the system template) because flatpak binaries are always executed inside the container with the full path.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
