### PR TITLE
Use an explicit path for sys.executable.

### DIFF
--- a/{{ cookiecutter.format }}/src/bootstrap/main.c
+++ b/{{ cookiecutter.format }}/src/bootstrap/main.c
@@ -61,8 +61,8 @@ int main(int argc, char *argv[]) {
     }
     PyMem_RawFree(wtmp_str);
 
-    // Set the executable name to match argv[0]
-    status = PyConfig_SetBytesString(&config, &config.executable, argv[0]);
+    // Set the executable to match the known path of the app binary in the flatpak.
+    status = PyConfig_SetBytesString(&config, &config.executable, "/app/bin/{{ cookiecutter.app_name }}");
     if (PyStatus_Exception(status)) {
         // crash_dialog("Unable to set executable name: %s", status.err_msg);
         PyConfig_Clear(&config);


### PR DESCRIPTION
#41 introduced a change to explicitly set sys.executable to argv[0]. This appears to work on Python 3.9+, but [fails on Python3.8](https://github.com/beeware/Python-support-testbed/actions/runs/8870342745/job/24352385014?pr=75) due to a difference in the implementation of `platform.platform()`.

Inside a flatpak, the location of the app binary is completely predictable, so this modifies the app stub to use the explicit path, rather than implying one from `sys.argv[0]`

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
