### PR TITLE
Bump Standalone Python from 20240415 -> 20240726

### DIFF
--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -1,14 +1,17 @@
 # Generated using Python {{ cookiecutter.python_version }}
+[briefcase]
+target_version = "0.3.20"
+
 [paths]
 app_path = "src/app"
 app_requirements_path = "requirements.txt"
 support_path = "support"
 {{ {
-    "3.8": 'support_revision = "3.8.19+20240415"',
-    "3.9": 'support_revision = "3.9.19+20240415"',
-    "3.10": 'support_revision = "3.10.14+20240415"',
-    "3.11": 'support_revision = "3.11.9+20240415"',
-    "3.12": 'support_revision = "3.12.3+20240415"',
+    "3.8": 'support_revision = "3.8.19+20240726"',
+    "3.9": 'support_revision = "3.9.19+20240726"',
+    "3.10": 'support_revision = "3.10.14+20240726"',
+    "3.11": 'support_revision = "3.11.9+20240726"',
+    "3.12": 'support_revision = "3.12.4+20240726"',
 }.get(cookiecutter.python_version|py_tag, "") }}
 
 


### PR DESCRIPTION
## Changes
- Use version [20240726](https://github.com/indygreg/python-build-standalone/releases/tag/20240726) of Standalone Python that includes stripped versions
- Introduces minimum platform version 0.3.20 since stripped versions of Standalone Python only exist for 20240726
- Bumps Python 3.12.3 -> 3.12.4

BRIEFCASE_REPO: https://github.com/rmartin16/briefcase
BRIEFCASE_REF: linux-stripped-python

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct