### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,5 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -7,10 +7,10 @@ app_path = "src/app"
 app_requirements_path = "requirements.txt"
 support_path = "support"
 {{ {
-    "3.9": 'support_revision = "3.9.19+20240726"',
-    "3.10": 'support_revision = "3.10.14+20240726"',
-    "3.11": 'support_revision = "3.11.9+20240726"',
-    "3.12": 'support_revision = "3.12.4+20240726"',
+    "3.9": 'support_revision = "3.9.19+20240814"',
+    "3.10": 'support_revision = "3.10.14+20240814"',
+    "3.11": 'support_revision = "3.11.9+20240814"',
+    "3.12": 'support_revision = "3.12.5+20240814"',
 }.get(cookiecutter.python_version|py_tag, "") }}
 
 

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -7,7 +7,6 @@ app_path = "src/app"
 app_requirements_path = "requirements.txt"
 support_path = "support"
 {{ {
-    "3.8": 'support_revision = "3.8.19+20240726"',
     "3.9": 'support_revision = "3.9.19+20240726"',
     "3.10": 'support_revision = "3.10.14+20240726"',
     "3.11": 'support_revision = "3.11.9+20240726"',


### PR DESCRIPTION
## Changes
- Drop Python 3.8 as Briefcase's `main` branch no longer supports it
- Bump to Standalone Python 20240814

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct