### PR TITLE
Decouple Python package install command from manifest

### DIFF
--- a/{{ cookiecutter.format }}/install_requirements.sh
+++ b/{{ cookiecutter.format }}/install_requirements.sh
@@ -1,0 +1,5 @@
+#! /usr/bin/env sh
+
+# Default pip-based installation. Briefcase may overwrite the contents of this file
+# to configure requirement installation as required by the app configuration.
+/app/bin/python3 -m pip install --no-cache-dir -r requirements.txt --target "$INSTALL_TARGET"

--- a/{{ cookiecutter.format }}/manifest.yml
+++ b/{{ cookiecutter.format }}/manifest.yml
@@ -75,10 +75,12 @@ modules:
       # command line compatible, and the output objects are compatible,
       # so we can override the CC build environment variable to force the
       # use of gcc.
-      - CC="gcc -pthread" /app/bin/python3 -m pip install --no-cache-dir -r requirements.txt --target /app/briefcase/app_packages
+      - env CC="gcc -pthread" INSTALL_TARGET="/app/briefcase/app_packages" sh ./install_requirements.sh
     sources:
       - type: file
         path: requirements.txt
+      - type: file
+        path: install_requirements.sh
   - name: app
     buildsystem: simple
     build-options:


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Related to https://github.com/beeware/briefcase/issues/1270

Facilitates configuration of the pip install command arguments by Briefcase or the use of a different package installer altogether without needing to re-process the template or add complex logic to the template (as would be required if the command was templated directly into the manifest).

The default contents of `install_requirements.sh` ensure this can be merged without waiting for Briefcase to support writing into the file (e.g., if a Briefcase version is released between this PR merging and the rest of the linked issue being implemented).

Alternatively, if the maintainers prefer, I can change the file to be blank by default, and we can wait to merge this until the Briefcase change is ready.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
