### PR TITLE
Use installer args file for pip options

### DIFF
--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -5,6 +5,7 @@ target_version = "0.3.20"
 [paths]
 app_path = "src/app"
 app_requirements_path = "requirements.txt"
+app_requirement_installer_args_path = "pip-options.txt"
 support_path = "support"
 {{ {
     "3.9": 'support_revision = "3.9.20+20241016"',

--- a/{{ cookiecutter.format }}/install_requirements.sh
+++ b/{{ cookiecutter.format }}/install_requirements.sh
@@ -1,5 +1,0 @@
-#! /usr/bin/env sh
-
-# Default pip-based installation. Briefcase may overwrite the contents of this file
-# to configure requirement installation as required by the app configuration.
-/app/bin/python3 -m pip install --no-cache-dir -r requirements.txt --target "$INSTALL_TARGET"

--- a/{{ cookiecutter.format }}/manifest.yml
+++ b/{{ cookiecutter.format }}/manifest.yml
@@ -75,12 +75,14 @@ modules:
       # command line compatible, and the output objects are compatible,
       # so we can override the CC build environment variable to force the
       # use of gcc.
-      - env CC="gcc -pthread" INSTALL_TARGET="/app/briefcase/app_packages" sh ./install_requirements.sh
+      - CC="gcc -pthread" /app/bin/python3 pip_install.py
     sources:
       - type: file
         path: requirements.txt
       - type: file
-        path: install_requirements.sh
+        path: pip-options.txt
+      - type: file
+        path: pip_install.py
   - name: app
     buildsystem: simple
     build-options:

--- a/{{ cookiecutter.format }}/pip_install.py
+++ b/{{ cookiecutter.format }}/pip_install.py
@@ -17,5 +17,14 @@ os.execv(
         "--target",
         "/app/briefcase/app_packages",
     ]
-    + Path(__file__).parent.joinpath("pip-options.txt").read_text().split("\n"),
+    + [
+        arg
+        for arg in Path(__file__)
+        .parent.joinpath("pip-options.txt")
+        .read_text()
+        .split("\n")
+        # skip empty lines, including trailing newlines or empty default file
+        # (which contains a single newline character)
+        if arg and not arg.isspace()
+    ],
 )

--- a/{{ cookiecutter.format }}/pip_install.py
+++ b/{{ cookiecutter.format }}/pip_install.py
@@ -1,13 +1,17 @@
 from pathlib import Path
 import os
+import sys
 
 # Run pip install with default arguments + options read from the app requirement
-# installer args path
+# installer args path.
+# execv is simpler than subprocess, as it avoids needing to manage the subprocess
+# or pipe in/out, which would add a lot of unnecessary complexity for no value.
+# This script only helps build the command, it does not need to check the output at all.
 
 os.execv(
-    "/app/bin/python3",
+    sys.executable,
     [
-        "/app/bin/python3",
+        sys.executable,
         "-m",
         "pip",
         "install",

--- a/{{ cookiecutter.format }}/pip_install.py
+++ b/{{ cookiecutter.format }}/pip_install.py
@@ -19,8 +19,7 @@ os.execv(
     ]
     + [
         arg
-        for arg in Path(__file__)
-        .parent.joinpath("pip-options.txt")
+        for arg in (Path(__file__).parent / "pip-options.txt")
         .read_text()
         .split("\n")
         # skip empty lines, including trailing newlines or empty default file

--- a/{{ cookiecutter.format }}/pip_install.py
+++ b/{{ cookiecutter.format }}/pip_install.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import os
+
+# Run pip install with default arguments + options read from the app requirement
+# installer args path
+
+os.execv(
+    "/app/bin/python3",
+    [
+        "/app/bin/python3",
+        "-m",
+        "pip",
+        "install",
+        "--no-cache-dir",
+        "-r",
+        "requirements.txt",
+        "--target",
+        "/app/briefcase/app_packages",
+    ]
+    + Path(__file__).parent.joinpath("pip-options.txt").read_text().split("\n"),
+)


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Related to https://github.com/beeware/briefcase/issues/1270

Follow up to #52

Based on the discussion in this PR to address the linked issue in Briefcase: https://github.com/beeware/briefcase/pull/2059#discussion_r1841597072. This PR depends on changes in 

A desire for a generic interface to define pip install arguments was expressed. Using Python to generate the `pip install` invocation and executing it with `execv` ensures that the method for reading the `pip-options.txt` file as a newline delimited list of command arguments is shell agnostic (e.g., does not rely on bash being the shell in order to use its arrays).

Not entirely sure if this is what y'all had in mind @freakboy3742 and @mhsmith but let me know your thoughts.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
