### PR TITLE
Add processing of .pth files from "app_packages".

### DIFF
--- a/{{ cookiecutter.format }}/src/bootstrap/main.c
+++ b/{{ cookiecutter.format }}/src/bootstrap/main.c
@@ -20,6 +20,8 @@ int main(int argc, char *argv[]) {
     char *app_module_name;
     char *path;
     wchar_t *wtmp_str;
+    wchar_t *app_packages_path_str;
+    PyObject *app_packages_path;
     PyObject *app_module;
     PyObject *module;
     PyObject *module_attr;
@@ -140,18 +142,6 @@ int main(int argc, char *argv[]) {
     }
     PyMem_RawFree(wtmp_str);
 
-    // Add the app_packages path
-    path = "/app/briefcase/app_packages";
-    debug_log("- %s\n", path);
-    wtmp_str = Py_DecodeLocale(path, NULL);
-    status = PyWideStringList_Append(&config.module_search_paths, wtmp_str);
-    if (PyStatus_Exception(status)) {
-        // crash_dialog("Unable to set app path: %s", status.err_msg);
-        PyConfig_Clear(&config);
-        Py_ExitStatusException(status);
-    }
-    PyMem_RawFree(wtmp_str);
-
     // Add the app path
     path = "/app/briefcase/app";
     debug_log("- %s\n", path);
@@ -179,6 +169,48 @@ int main(int argc, char *argv[]) {
         PyConfig_Clear(&config);
         Py_ExitStatusException(status);
     }
+
+
+    // Adding the app_packages as site directory.
+    //
+    // This adds app_packages to sys.path and executes any .pth
+    // files in that directory.
+    path = "/app/briefcase/app_packages";
+    app_packages_path_str = Py_DecodeLocale(path, NULL);
+   
+    debug_log("Adding app_packages as site directory: %S\n", app_packages_path_str);
+
+    module = PyImport_ImportModule("site");
+    if (module == NULL) {
+        // crash_dialog("Could not import site module");
+        exit(-8);
+    }
+    
+    module_attr = PyObject_GetAttrString(module, "addsitedir");
+    if (module_attr == NULL || !PyCallable_Check(module_attr)) {
+        // crash_dialog("Could not access site.addsitedir");
+        exit(-9);
+    }
+    
+    app_packages_path = PyUnicode_FromWideChar(app_packages_path_str, wcslen(app_packages_path_str));
+    if (app_packages_path == NULL) {
+        //crash_dialog("Could not convert app_packages path to unicode");
+        exit(-10);
+    }
+    PyMem_RawFree(app_packages_path_str);
+
+    method_args = Py_BuildValue("(O)", app_packages_path);
+    if (method_args == NULL) {
+        // crash_dialog("Could not create arguments for site.addsitedir");
+        exit(-11);
+    }
+
+    result = PyObject_CallObject(module_attr, method_args);
+    if (result == NULL) {
+        // crash_dialog("Could not add app_packages directory using site.addsitedir");
+        exit(-12);
+    }
+
 
     // Start the app module.
     //

--- a/{{ cookiecutter.format }}/src/bootstrap/main.c
+++ b/{{ cookiecutter.format }}/src/bootstrap/main.c
@@ -183,32 +183,32 @@ int main(int argc, char *argv[]) {
     module = PyImport_ImportModule("site");
     if (module == NULL) {
         // crash_dialog("Could not import site module");
-        exit(-8);
+        exit(-11);
     }
 
     module_attr = PyObject_GetAttrString(module, "addsitedir");
     if (module_attr == NULL || !PyCallable_Check(module_attr)) {
         // crash_dialog("Could not access site.addsitedir");
-        exit(-9);
+        exit(-12);
     }
 
     app_packages_path = PyUnicode_FromWideChar(app_packages_path_str, wcslen(app_packages_path_str));
     if (app_packages_path == NULL) {
         //crash_dialog("Could not convert app_packages path to unicode");
-        exit(-10);
+        exit(-13);
     }
     PyMem_RawFree(app_packages_path_str);
 
     method_args = Py_BuildValue("(O)", app_packages_path);
     if (method_args == NULL) {
         // crash_dialog("Could not create arguments for site.addsitedir");
-        exit(-11);
+        exit(-14);
     }
 
     result = PyObject_CallObject(module_attr, method_args);
     if (result == NULL) {
         // crash_dialog("Could not add app_packages directory using site.addsitedir");
-        exit(-12);
+        exit(-15);
     }
 
 

--- a/{{ cookiecutter.format }}/src/bootstrap/main.c
+++ b/{{ cookiecutter.format }}/src/bootstrap/main.c
@@ -177,7 +177,7 @@ int main(int argc, char *argv[]) {
     // files in that directory.
     path = "/app/briefcase/app_packages";
     app_packages_path_str = Py_DecodeLocale(path, NULL);
-   
+
     debug_log("Adding app_packages as site directory: %S\n", app_packages_path_str);
 
     module = PyImport_ImportModule("site");
@@ -185,13 +185,13 @@ int main(int argc, char *argv[]) {
         // crash_dialog("Could not import site module");
         exit(-8);
     }
-    
+
     module_attr = PyObject_GetAttrString(module, "addsitedir");
     if (module_attr == NULL || !PyCallable_Check(module_attr)) {
         // crash_dialog("Could not access site.addsitedir");
         exit(-9);
     }
-    
+
     app_packages_path = PyUnicode_FromWideChar(app_packages_path_str, wcslen(app_packages_path_str));
     if (app_packages_path == NULL) {
         //crash_dialog("Could not convert app_packages path to unicode");


### PR DESCRIPTION
As described [here](https://github.com/beeware/briefcase/issues/2195#issuecomment-2727821874), the `app_packages` should be added via `site.addsitedir()` so that `.pth` files are executed correctly.

I tested it with a minimal example project I made for this: [pth-execution-checker](https://github.com/timrid/pth-execution-checker)

Should fix https://github.com/beeware/briefcase/issues/2195, https://github.com/beeware/briefcase/issues/669 and https://github.com/beeware/briefcase/issues/381 for "linux flatpak".

There is also a similar PR for "windows visualstudio": https://github.com/beeware/briefcase-windows-VisualStudio-template/pull/52

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct