### PR TITLE
Drop Python 3.9, add 3.14.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,14 @@ jobs:
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]
         runner-os: [ "ubuntu-24.04", "ubuntu-24.04-arm" ]
-        # Pygame hasn't published 3.14 wheels yet.
+        # Pygame and PySide6 haven't published 3.14 wheels yet.
         exclude:
+          - python-version: "3.14"
+            framework: pyside6
+            runner-os: "ubuntu-24.04"
+          - python-version: "3.14"
+            framework: pyside6
+            runner-os: "ubuntu-24.04-arm"
           - python-version: "3.14"
             framework: pygame
             runner-os: "ubuntu-24.04"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         framework: [ "toga", "pyside6", "pygame", "console" ]
         runner-os: [ "ubuntu-24.04", "ubuntu-24.04-arm" ]
+        # Pygame hasn't published 3.14 wheels yet.
+        exclude:
+          - python-version: "3.14"
+            framework: pygame
+            runner-os: "ubuntu-24.04"
+          - python-version: "3.14"
+            framework: pygame
+            runner-os: "ubuntu-24.04-arm"

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -8,11 +8,11 @@ app_requirements_path = "requirements.txt"
 app_requirement_installer_args_path = "pip-options.txt"
 support_path = "support"
 {{ {
-    "3.9": 'support_revision = "3.9.22+20250409"',
-    "3.10": 'support_revision = "3.10.17+20250409"',
-    "3.11": 'support_revision = "3.11.12+20250409"',
-    "3.12": 'support_revision = "3.12.10+20250409"',
-    "3.13": 'support_revision = "3.13.3+20250409"',
+    "3.10": 'support_revision = "3.10.18+20250723"',
+    "3.11": 'support_revision = "3.11.13+20250723"',
+    "3.12": 'support_revision = "3.12.11+20250723"',
+    "3.13": 'support_revision = "3.13.5+20250723"',
+    "3.14": 'support_revision = "3.14.0rc1+20250723"',
 }.get(cookiecutter.python_version|py_tag, "") }}
 
 

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -8,11 +8,11 @@ app_requirements_path = "requirements.txt"
 app_requirement_installer_args_path = "pip-options.txt"
 support_path = "support"
 {{ {
-    "3.10": 'support_revision = "3.10.18+20250723"',
-    "3.11": 'support_revision = "3.11.13+20250723"',
-    "3.12": 'support_revision = "3.12.11+20250723"',
-    "3.13": 'support_revision = "3.13.5+20250723"',
-    "3.14": 'support_revision = "3.14.0rc1+20250723"',
+    "3.10": 'support_revision = "3.10.18+20250808"',
+    "3.11": 'support_revision = "3.11.13+20250808"',
+    "3.12": 'support_revision = "3.12.11+20250808"',
+    "3.13": 'support_revision = "3.13.6+20250808"',
+    "3.14": 'support_revision = "3.14.0rc1+20250808"',
 }.get(cookiecutter.python_version|py_tag, "") }}
 
 

--- a/{{ cookiecutter.format }}/manifest.yml
+++ b/{{ cookiecutter.format }}/manifest.yml
@@ -4,6 +4,9 @@ runtime: {{ cookiecutter.flatpak_runtime }}
 runtime-version: '{{ cookiecutter.flatpak_runtime_version }}'
 sdk: {{ cookiecutter.flatpak_sdk }}
 command: {{ cookiecutter.app_name }}
+build-options:
+  strip: false
+  no-debuginfo: true
 cleanup:
   - /include
   - /share/man

--- a/{{ cookiecutter.format }}/manifest.yml
+++ b/{{ cookiecutter.format }}/manifest.yml
@@ -66,8 +66,6 @@ modules:
   - name: app_packages
     buildsystem: simple
     build-options:
-      strip: false
-      no-debuginfo: true
       build-args:
         - --filesystem=host  # For local requirements.
         - --share=network  # For downloaded requirements.
@@ -88,9 +86,6 @@ modules:
         path: pip_install.py
   - name: app
     buildsystem: simple
-    build-options:
-      strip: false
-      no-debuginfo: true
     build-commands:
       - mkdir -p /app/briefcase
       - cp --archive src/app/ /app/briefcase/app

--- a/{{ cookiecutter.format }}/src/bootstrap/main.c
+++ b/{{ cookiecutter.format }}/src/bootstrap/main.c
@@ -43,6 +43,8 @@ int main(int argc, char *argv[]) {
     // Enforce UTF-8 encoding for stderr, stdout, file-system encoding and locale.
     // See https://docs.python.org/3/library/os.html#python-utf-8-mode.
     preconfig.utf8_mode = 1;
+    // Ensure the locale is set (isolated interpreters won't by default)
+    preconfig.configure_locale = 1;
     // Don't buffer stdio. We want output to appears in the log immediately
     config.buffered_stdio = 0;
     // Don't write bytecode; we can't modify the app bundle


### PR DESCRIPTION
Python 3.9 is EOL; 3.14 is now available.

Also includes the fix for locale initialization (see beeware/briefcase-iOS-Xcode-template#57).

Needs to be updated to 3.14.0 final when Astral publishes the package.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
