### PR TITLE
Add Flatpak base support

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -12,6 +12,8 @@
     "flatpak_runtime": "org.freedesktop.Platform",
     "flatpak_runtime_version": "21.08",
     "flatpak_sdk": "org.freedesktop.Sdk",
+    "flatpak_base": "",
+    "flatpak_base_version": "",
     "finish_args": "",
     "modules_extra_content": "",
     "python_version": "3.X.0",

--- a/{{ cookiecutter.format }}/manifest.yml
+++ b/{{ cookiecutter.format }}/manifest.yml
@@ -2,6 +2,10 @@ app-id: {{ cookiecutter.bundle_identifier }}
 default-branch: {{ cookiecutter.version }}
 runtime: {{ cookiecutter.flatpak_runtime }}
 runtime-version: '{{ cookiecutter.flatpak_runtime_version }}'
+{%- if cookiecutter.flatpak_base or cookiecutter.flatpak_base_version %}
+base: {{ cookiecutter.flatpak_base }}
+base-version: '{{ cookiecutter.flatpak_base_version }}'
+{%- endif %}
 sdk: {{ cookiecutter.flatpak_sdk }}
 command: {{ cookiecutter.app_name }}
 build-options:


### PR DESCRIPTION
<!--- Describe your changes in detail -->

Adds the optional ability for the user to add a base to the `manifest.yml`.

<!--- What problem does this change solve? -->

Base is different from runtime. This can help fix PySide, for example, by using https://github.com/flathub/com.riverbankcomputing.PyQt.BaseApp/ as the base.

```
id: org.kde.PyQtWebEngineApp
runtime: org.kde.Platform
runtime-version: '6.9'
sdk: org.kde.Sdk
base: com.riverbankcomputing.PyQt.BaseApp
base-version: '6.9'
cleanup-commands:
  - /app/cleanup-BaseApp.sh
finish-args:
  - --env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
  ...
modules:
  - name: PyQtWebEngineApp
...
```

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Refs:
* https://github.com/beeware/briefcase/pull/2478
* https://github.com/beeware/briefcase/issues/2182

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
